### PR TITLE
Expect not empty member variables in prepareSelect. E.g. when a signa…

### DIFF
--- a/PhpAmqpLib/Wire/IO/AbstractIO.php
+++ b/PhpAmqpLib/Wire/IO/AbstractIO.php
@@ -102,12 +102,9 @@ abstract class AbstractIO
             return;
         }
 
-        if (null !== $this->originalSignalHandlers) {
-            throw new AMQPIOException('The originalSignalHandlers property is not null. The afterSelect method might not have been called.');
-        }
-
-        if (null !== $this->gotSignalWhileSelecting) {
-            throw new AMQPIOException('The gotSignalWhileSelecting property is not null. The afterSelect method might not have been called.');
+        if (null !== $this->originalSignalHandlers || null !== $this->gotSignalWhileSelecting) {
+            // This could happen in a race condition -> when a signal is received, while we are in the signal handler
+            return;
         }
 
         $this->originalSignalHandlers = [];


### PR DESCRIPTION
…l is received, while we are in the signal handler